### PR TITLE
Corrected the repo name to "spark_log_parser" in the python3 call

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you have not already done so, complete the [instructions](docs/event_log_down
 1. To process a log file, execute the parse.py script in the sync_parser folder, and provide a
 log file destination with the -d flag.
 
-    `python3 sync_parser/parse.py -d [log file location]`
+    `python3 spark_log_parser/parse.py -d [log file location]`
 
     The parsed file `parsed-[log file name]` will appear in the results directory.
 


### PR DESCRIPTION
Changed the instructions from "sync_parser" to "spark_log_parser".  I encountered this bug when I used the parser myself.