### PR TITLE
Prod 411 hui adobe parser error databricks on azure

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,3 +1,3 @@
 """Tools for providing Spark event log"""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -134,10 +134,14 @@ class sparkApplication:
             sql_jobs = []
             sql_stages = []
             sql_tasks = []
-            for jid, job in appobj.jobs.items():
 
-                if "end_time" not in sql.keys():
-                    sql["end_time"] = appobj.finish_time
+            # Sometimes an SQL event will be missing. To be informative, both
+            # events must be present. But this information is not critical, so 
+            # if either event is missing then simply reject the SQL data
+            if "start_time" not in sql.keys() or "end_time" not in sql.keys():
+                continue
+            
+            for jid, job in appobj.jobs.items():
 
                 if (job.submission_time >= sql["start_time"]) and (
                     job.submission_time <= sql["end_time"]

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -136,11 +136,11 @@ class sparkApplication:
             sql_tasks = []
 
             # Sometimes an SQL event will be missing. To be informative, both
-            # events must be present. But this information is not critical, so 
+            # events must be present. But this information is not critical, so
             # if either event is missing then simply reject the SQL data
             if "start_time" not in sql.keys() or "end_time" not in sql.keys():
                 continue
-            
+
             for jid, job in appobj.jobs.items():
 
                 if (job.submission_time >= sql["start_time"]) and (

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -64,3 +64,13 @@ def test_simple_emr_log():
     assert (
         parsed["metadata"]["application_info"]["name"] == "Text Similarity"
     ), "Name is as expected"
+
+
+def test_emr_missing_sql_events():
+    event_log_path = Path("tests", "logs", "emr_missing_sql_events.zip").resolve()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        event_log = eventlog.EventLogBuilder(event_log_path.as_uri(), temp_dir).build()
+        obj = sparkApplication(eventlog=str(event_log))
+
+    assert list(obj.sqlData.index.values) == [0, 2, 3, 5, 6, 7, 8]


### PR DESCRIPTION
Sometimes SQL Submission or Completion events are missing which throws an error. However, these events are not critical for the predictor run. This solution bypasses the problem by neglecting the SQL data for any queries for which either the Submission or Completion events is missing.

Also added a test for this case which indicates the effect on the sqlData dataframe.

Also modified version.