### PR TITLE
[PROD-429] Handle event logs with no application end events

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ If you have not already done so, complete the [instructions](https://github.com/
 ### Step 1: Parse the log to strip away sensitive information
 1. To process a log file execute the spark-log-parser command with a log file path and a directory in which to store the result like so:
     ```shell
-    spark-log-parser -l <log file location> -r <results directory>
+    spark-log-parser -l <log file location> -r <result directory>
     ```
-    The parsed file `parsed-<log file name>` will appear in the results directory.
+    The parsed file `parsed-<log file name>` will appear in the result directory.
 
 2. Send Sync Computing the parsed log
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@ pip3 install https://github.com/synccomputingcode/spark_log_parser/archive/main.
 If you have not already done so, complete the [instructions](https://github.com/synccomputingcode/user_documentation/wiki#accessing-autotuner-input-data) to download the Apache Spark event log.
 
 ### Step 1: Parse the log to strip away sensitive information
-1. To process a log file, execute the parse.py script in the sync_parser folder, and provide a
-log file destination with the -l flag.
-
+1. To process a log file execute the spark-log-parser command with a log file path and a directory in which to store the result like so:
     ```shell
     spark-log-parser -l <log file location> -r <results directory>
     ```
-
     The parsed file `parsed-<log file name>` will appear in the results directory.
-
 
 2. Send Sync Computing the parsed log
 

--- a/spark_log_parser/parsing_models/validation_event_data.py
+++ b/spark_log_parser/parsing_models/validation_event_data.py
@@ -1,19 +1,21 @@
+import logging
+
 from .exceptions import LazyEventValidationException
 from .exceptions import ParserErrorMessages as MSGS
 
-import logging
-
 logger = logging.getLogger("EventDataValidation")
 
-class EventDataValidation():
+
+class EventDataValidation:
     """
     Validate the existence of certain Spark Listener Events
     """
+
     def __init__(self, app=None, debug=False):
 
         self.app = app
-        self.debug = debug # When 'True' disables exception raises for debugging
-        self.message = ''
+        self.debug = debug  # When 'True' disables exception raises for debugging
+        self.message = ""
 
     def validate(self):
         """
@@ -21,44 +23,48 @@ class EventDataValidation():
         and exception. Logging is used here so that the problem is still indicated when in debug
         mode.
         """
+        if not self.app.finish_time:
+            self.message += (
+                f"{MSGS.MISSING_EVENT_GENERIC_MESSAGE} 'Application / Stage / SQL Completion'. "
+            )
+
         self.validate_job_events()
         self.validate_stage_events()
 
-        if (len(self.message)>0):
+        if len(self.message) > 0:
             logger.error(self.message)
             if not self.debug:
-                raise LazyEventValidationException(error_message = self.message)
+                raise LazyEventValidationException(error_message=self.message)
 
     def validate_job_events(self):
         """
-        Look for missing job events. 
-        
+        Look for missing job events.
+
         4/20/2022: Currently only the JobComplete is detected, because a missing
         JobStart event will result in a more urgent exception being thrown in SparkApplication
         """
 
         miss_job_ends = []
         for jid, job in self.app.jobs.items():
-            if not hasattr(job, 'completion_time'):
+            if not hasattr(job, "completion_time"):
                 miss_job_ends.append(jid)
 
-        if len(miss_job_ends)>0:
-            msg = f'{MSGS.MISSING_EVENT_JOB_END}{miss_job_ends}. '
-            self.message += f'{MSGS.MISSING_EVENT_JOB_END}{miss_job_ends}. '
+        if len(miss_job_ends) > 0:
+            self.message += f"{MSGS.MISSING_EVENT_JOB_END}{miss_job_ends}. "
 
     def validate_stage_events(self):
         """
-        Look for missing stage events. 
-        
-        4/20/2022: Currently only the StageSubmitted is detected, because a 
-        missing StageCompleted event will result in a more urgent exception being thrown in 
+        Look for missing stage events.
+
+        4/20/2022: Currently only the StageSubmitted is detected, because a
+        missing StageCompleted event will result in a more urgent exception being thrown in
         SparkApplication
         """
         miss_stage_completes = []
         for jid, job in self.app.jobs.items():
             for sid, stage in job.stages.items():
-                if not hasattr(stage, 'completion_time'):
+                if not hasattr(stage, "completion_time"):
                     miss_stage_completes.append(sid)
 
-        if len(miss_stage_completes)>0:
-            self.message += f'{MSGS.MISSING_EVENT_STAGE_COMPLETE}{miss_stage_completes}.  '
+        if len(miss_stage_completes) > 0:
+            self.message += f"{MSGS.MISSING_EVENT_STAGE_COMPLETE}{miss_stage_completes}.  "

--- a/spark_log_parser/parsing_models/validation_event_data.py
+++ b/spark_log_parser/parsing_models/validation_event_data.py
@@ -25,7 +25,7 @@ class EventDataValidation:
         """
         if not self.app.finish_time:
             self.message += (
-                f"{MSGS.MISSING_EVENT_GENERIC_MESSAGE} 'Application / Stage / SQL Completion'. "
+                MSGS.MISSING_EVENT_GENERIC_MESSAGE + "'Application / Stage / SQL Completion'. "
             )
 
         self.validate_job_events()


### PR DESCRIPTION
https://synccomputing.atlassian.net/browse/PROD-429

In the case described in the ticket there are no stage, SQL or application end events in the log. There are only these events:
```
% jq -r .Event issues/prod-429/eventlog
DBCEventLoggingListenerMetadata
SparkListenerResourceProfileAdded
SparkListenerBlockManagerAdded
SparkListenerEnvironmentUpdate
SparkListenerApplicationStart
SparkListenerExecutorAdded
SparkListenerBlockManagerAdded
```
In this scenario the `finish_time` on the application is not set leading to the exception described in the ticket. The solution here builds on the validation that mandates end events for jobs and stages to also mandate events required to set the finish time.

Formatting removed the carriage returns so the file looks completely changed, but really only lines [26,29] were added.

A test for the solution is provided in https://github.com/synccomputingcode/sync_backend/pull/184