### PR TITLE
Change default chunk_size to 1MB for streamed HTTP responses

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,2 +1,2 @@
 """Tools for providing Spark event log"""
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
As I was poking around familiarizing myself with DataDog, I noticed that the CPU Profiling stack traces for our prediction tasks seemed to spend a LARGE amount of time simply downloading the log files -

![Screenshot 2022-11-09 at 6 11 15 PM](https://user-images.githubusercontent.com/117235708/200983348-14941631-d841-4f61-a902-3e35d03981c5.png)

Looking at `Extractor._download`, I noticed we are using streaming responses and iterating over the chunks of the response to accumulate those chunks into a file. However, I noticed in the docstring of `response.iter_content()` that by default it only processes the stream _one byte at a time_ -

```python
    def iter_content(self, chunk_size=1, decode_unicode=False):
        """Iterates over the response data.  When stream=True is set on the
        request, this avoids reading the content at once into memory for
        large responses.  The chunk size is the number of bytes it should
        read into memory.  This is not necessarily the length of each item
        returned as decoding can take place.
```

I was able to reproduce this locally using the current NodeJS LTS download as a test file (421 MB), which took just over 3 minutes to download -

```python
import requests, time
response = requests.get("https://nodejs.org/dist/v18.12.1/node-v18.12.1.tar.gz",
                        headers={'Cache-Control': 'no-cache'},
                        stream=True)
t0 = time.time()
arr = []
for chunk in response.iter_content():
    arr.append(chunk)
t1 = time.time()
print(f"Took {t1 - t0} second")
Took 193.0412311553955 milliseconds
```

Replacing this with a chunk size of 1MB, the same file takes only 7 seconds to download (note the use of the `no-cache` header to ensure we are fetching from a remote source and not hitting a local HTTP cache) -

```python
import requests, time
response = requests.get("https://nodejs.org/dist/v18.12.1/node-v18.12.1.tar.gz",
                        headers={'Cache-Control': 'no-cache'},
                        stream=True)
t0 = time.time()
arr = []
for chunk in response.iter_content(chunk_size=1024 * 1024):
    arr.append(chunk)
t1 = time.time()
print(f"Took {t1 - t0} seconds")
Took 7.057264804840088 seconds
```

It's worth noting that using `chunk_size=1024` (1 Kb) seems to perform about the same as using a size of 1 MB, so I'm not 100% sure what the pros/cons here would be. My gut feeling is that a larger chunk size may be beneficial for larger files, but maybe a little more wasteful memory-wise for small files. Regardless, both options are a huge improvement!


Extra info, for those curious - 

This timing discrepancy hinted to me that this `chunk_size` argument has an effect on the actual connection/how data makes it to us from the file server, and so I re-ran these tests with a Wireshark capture going. In addition to downloading packets faster/more at once, using a chunk size of 1MB resulted in almost 20% fewer packets over the wire during the course of the download -

`chunk_size=1` showing almost 100k packets related to the download -
<img width="306" alt="Screenshot 2022-11-10 at 11 10 34 AM" src="https://user-images.githubusercontent.com/117235708/201185536-31d84bf5-cf18-4a6a-b0df-c835ec10f135.png">

`chunk_size=1024 * 1024` showing ~82k packets related to the download -
<img width="263" alt="Screenshot 2022-11-10 at 11 11 02 AM" src="https://user-images.githubusercontent.com/117235708/201185704-bff973cb-b066-434b-b83e-6825641a1043.png">

By my eye, these extra packets are likely due to requiring fewer TCP ACKs/retranmissions when the chunk size is larger. Also, worth noting that `chunk_size=1024` generated almost exactly the same amount of packets as `chunk_size=1024 * 1024`