### PR TITLE
Handle empty downloads

### DIFF
--- a/spark_log_parser/extractor.py
+++ b/spark_log_parser/extractor.py
@@ -32,7 +32,7 @@ class Extractor:
         s3_client=None,
         thresholds=ExtractThresholds(),
         # For data over https, default to loading 1MB chunks of the file at a time
-        http_chunk_size=1024 * 1024
+        http_chunk_size=1024 * 1024,
     ):
         self.source_url = self._validate_url(source_url)
         self.work_dir = self._validate_work_dir(work_dir)
@@ -235,6 +235,9 @@ class Extractor:
         if self.source_url.scheme == "https":
             response = requests.get(self.source_url.geturl(), stream=True)
             response.raise_for_status()
+
+            if not int(response.headers.get("Content-Length", 0)):
+                raise AssertionError("Download is empty")
 
             target_path = self.work_dir.joinpath(self.source_url.path.split("/")[-1])
             with open(target_path, "wb") as fobj:


### PR DESCRIPTION
https://synccomputing.atlassian.net/browse/BT-242

We've been getting some [errors in production](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aproduction%20service%3Async_backend%20resource_name%3Async.prediction%20error.type%3A%22builtins.IsADirectoryError%22%20%40usr.org%3A%22Sync%20Computing%22&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_duration.by_service%2Cerror.type&historicalData=true&messageDisplay=inline&sort=desc&spanType=service-entry&spanViewType=errors&start=1667972602073&end=1668577402073&paused=false) from pre-signed URLs to empty content. Turns out they're from predictions started by Job Bank after an EMR job has failed. At any rate, this is a good opportunity to handle this scenario a little better.