### PR TITLE
PROD-582 Make ApplicationModel robust to receiving log lines out-of-order

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,2 +1,2 @@
 """Tools for providing Spark event log"""
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/spark_log_parser/parsing_models/application_model.py
+++ b/spark_log_parser/parsing_models/application_model.py
@@ -174,7 +174,6 @@ class ApplicationModel:
                 elif event_type == "SparkListenerEnvironmentUpdate":
 
                     spark_properties = json_data["Spark Properties"]
-                    event_keys = spark_properties.keys()
 
                     # This if is specifically for databricks logs
                     if spark_version := spark_properties.get(
@@ -195,26 +194,6 @@ class ApplicationModel:
                         self.emr_version_tag = json_data["System Properties"]["EMR_RELEASE_LABEL"]
 
                     self.spark_metadata = {**self.spark_metadata, **spark_properties}
-
-                    ##################################
-                    # Note to predictor team:
-                    # Keeping these for now so nothing breaks, but adding transferring the entire Spark Properties dictionary above
-                    # so we can see what has been set and don't have to manually grab every property. Should be able to remove the
-                    # section below once we make minor tweaks to predictor.
-                    ##################################
-
-                    # if 'spark.executor.instances' in event_keys:
-                    #     self.num_executors = int(spark_properties["spark.executor.instances"])
-                    if "spark.default.parallelism" in event_keys:
-                        self.parallelism = int(spark_properties["spark.default.parallelism"])
-                    if "spark.executor.memory" in event_keys:
-                        self.memory_per_executor = spark_properties["spark.executor.memory"]
-                    # if 'spark.executor.cores' in event_keys:
-                    #    self.cores_per_executor = int(spark_properties["spark.executor.cores"])
-                    if "spark.sql.shuffle.partitions" in event_keys:
-                        self.shuffle_partitions = int(
-                            spark_properties["spark.sql.shuffle.partitions"]
-                        )
 
                 elif event_type == "SparkListenerExecutorAdded":
                     executor_id = json_data["Executor ID"]
@@ -339,11 +318,6 @@ class ApplicationModel:
 
         for job_id, job in self.jobs.items():
             job.initialize_job()
-
-    def output_all_job_info(self):
-        for job_id, job in self.jobs.items():
-            features_filename = f"{os.path.dirname(self.eventlogpath)}/e{self.num_executors}_p{self.parallelism}_mem{self.memory_per_executor}_job{job_id}"
-            job.write_features(features_filename)
 
     def maybe_set_new_finish_time(self, new_finish_time: int):
         """

--- a/spark_log_parser/parsing_models/application_model.py
+++ b/spark_log_parser/parsing_models/application_model.py
@@ -289,10 +289,7 @@ class ApplicationModel:
             self.cloud_platform = "emr"
             self.cloud_provider = "aws"
 
-        self.dag.decipher_dag()
-        self.dag.add_broadcast_dependencies(self.stdoutpath)
-
-        self.num_instances = len(numpy.unique(hosts))
+        self.num_instances = len(hosts)
         self.executors_per_instance = numpy.ceil(self.num_executors / self.num_instances)
 
         for task in self.tasks:
@@ -318,6 +315,9 @@ class ApplicationModel:
 
         for job_id, job in self.jobs.items():
             job.initialize_job()
+
+        self.dag.decipher_dag()
+        self.dag.add_broadcast_dependencies(self.stdoutpath)
 
     def maybe_set_new_finish_time(self, new_finish_time: int):
         """

--- a/spark_log_parser/parsing_models/application_model.py
+++ b/spark_log_parser/parsing_models/application_model.py
@@ -1,6 +1,5 @@
 import collections
 import gzip
-import os
 
 import boto3
 import numpy

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -473,8 +473,8 @@ class sparkApplication:
                 rdd_ids.append(appobj.dag.stage_rdd_dict[sid])
 
                 stage_info_dict = {
-                    "stage_name": stage.stage_info["Stage Name"],
-                    "num_tasks": stage.stage_info["Number of Tasks"],
+                    "stage_name": stage.stage_name,
+                    "num_tasks": stage.num_tasks,
                     "num_rdds": len(stage.stage_info["RDD Info"]),
                     "num_parents": len(stage.stage_info["Parent IDs"]),
                     "final_rdd_name": stage.stage_info["RDD Info"][0]["Name"],
@@ -597,11 +597,11 @@ class sparkApplication:
                 "emr_version_tag": appobj.emr_version_tag,
                 "cloud_platform": appobj.cloud_platform,
                 "cloud_provider": appobj.cloud_provider,
-                "cluster_id": appobj.cluster_id
+                "cluster_id": appobj.cluster_id,
             },
             "spark_params": appobj.spark_metadata,
             "existsSQL": self.existsSQL,
-            "existsExecutors": self.existsExecutors
+            "existsExecutors": self.existsExecutors,
         }
 
     def addMetadata(self, key=None, value=None):

--- a/spark_log_parser/parsing_models/dag_model.py
+++ b/spark_log_parser/parsing_models/dag_model.py
@@ -18,11 +18,11 @@ def parse_line(line, pattern, var_names):
 class DagModel:
     def __init__(self):
         self.stage_dict = {}  # <k="stage_id", v="trans_id" >
-        self.alias_dict = defaultdict(lambda: [])  # <k="trans_id", v=["stage_id"]>
-        self.parents_dag_dict = defaultdict(lambda: [])  # <k="parent_stage", v=["child_stage"]>
-        self.rdd_stage_dict = defaultdict(lambda: [])  # <k="RDD_id", v=["Stage_IDs"]  >
-        self.stage_rdd_dict = defaultdict(lambda: [])  # <k="stage_id", v=["RDD_ids"]    >
-        self.rdd_parent_dict = defaultdict(lambda: [])  # <k="RDD_id", v=["RDD_parents"]>
+        self.alias_dict = defaultdict(list)  # <k="trans_id", v=["stage_id"]>
+        self.parents_dag_dict = defaultdict(list)  # <k="parent_stage", v=["child_stage"]>
+        self.rdd_stage_dict = defaultdict(list)  # <k="RDD_id", v=["Stage_IDs"]  >
+        self.stage_rdd_dict = defaultdict(list)  # <k="stage_id", v=["RDD_ids"]    >
+        self.rdd_parent_dict = defaultdict(list)  # <k="RDD_id", v=["RDD_parents"]>
         self.rdd_persist_dict = {}  # <k="stage_id", v="persist?"     >
         self.broadcast_stages = []  # stages that have BroadcastExchange
 

--- a/spark_log_parser/parsing_models/executor_model.py
+++ b/spark_log_parser/parsing_models/executor_model.py
@@ -1,15 +1,11 @@
-import numpy
-
-
 class ExecutorModel:
     """
-    Model for a task within a stage
+    Model for a Spark Executor (i.e. worker node)
     """
-    def __init__(self, data):
 
-        self.id          = data['Executor ID']
-        self.start_time  = data['Timestamp']
-        self.end_time    = None 
-        self.host        = data['Executor Info']['Host']
-        self.cores       = data['Executor Info']['Total Cores']
-        
+    id: str = None
+    host: str = None
+    cores: int = None
+    start_time: int = None
+    end_time: int = None
+    removed_reason: str = ""

--- a/spark_log_parser/parsing_models/stage_model.py
+++ b/spark_log_parser/parsing_models/stage_model.py
@@ -2,48 +2,83 @@ import numpy
 
 from .task_model import TaskModel
 
+
 class StageModel:
     """
     Model for a stage within a spark job
     """
-    def __init__(self):
-        self.start_time = -1
-        self.tasks = []
 
-    
+    def __init__(self):
+        self.id: int = None
+        self.stage_name: str = None
+        # By default, Stages will have a "Stage Attempt ID" of 0 the first time they are run.
+        # If a Stage fails for some reason, it may be re-tried, and appear again in the eventlog with the
+        # "Stage Attempt ID" incremented by 1. As such, we want to keep track of this so that we aren't putting
+        # "stale" data onto a Stage when processing the eventlog lines (i.e. we don't want to set the `submission_time`
+        # to be that of Attempt ID 0 when we've already encountered Attempt ID 1!)
+        self.attempt_id: int = None
+        self.stage_info: dict = None
+        self.start_time: int = -1
+        self.tasks: list[TaskModel] = []
+        self.tasks_finalized: bool = False
+        self.num_tasks: int = 0
+        self.submission_time: int = None
+        self.completion_time: int = None
+
     def average_task_runtime(self):
-        return numpy.percentile([t.compute_time() for t in self.tasks], 50) if len(self.tasks) > 0 else 0
+        return (
+            numpy.percentile([t.compute_time() for t in self.tasks], 50)
+            if len(self.tasks) > 0
+            else 0
+        )
 
     def average_executor_deserialize_time(self):
-        return sum([t.executor_deserialize_time for t in self.tasks]) * 1.0 / len(self.tasks) if len(self.tasks) > 0 else 0
+        return (
+            sum([t.executor_deserialize_time for t in self.tasks]) * 1.0 / len(self.tasks)
+            if len(self.tasks) > 0
+            else 0
+        )
 
     def average_result_serialization_time(self):
-        return sum([t.result_serialization_time for t in self.tasks]) * 1.0 / len(self.tasks) if len(self.tasks) > 0 else 0  
+        return (
+            sum([t.result_serialization_time for t in self.tasks]) * 1.0 / len(self.tasks)
+            if len(self.tasks) > 0
+            else 0
+        )
 
     def total_executor_deserialize_time(self):
-        return sum([t.executor_deserialize_time for t in self.tasks]) 
+        return sum([t.executor_deserialize_time for t in self.tasks])
 
     def total_result_serialization_time(self):
-        return sum([t.result_serialization_time for t in self.tasks])     
+        return sum([t.result_serialization_time for t in self.tasks])
 
     def total_scheduler_delay(self):
-        return sum([t.scheduler_delay for t in self.tasks])     
+        return sum([t.scheduler_delay for t in self.tasks])
 
     def total_peak_execution_memory(self):
-        return sum([t.peak_execution_memory for t in self.tasks])            
+        return sum([t.peak_execution_memory for t in self.tasks])
 
     def average_scheduler_delay(self):
-        return sum([t.scheduler_delay for t in self.tasks]) * 1.0 / len(self.tasks) if len(self.tasks) > 0 else 0
+        return (
+            sum([t.scheduler_delay for t in self.tasks]) * 1.0 / len(self.tasks)
+            if len(self.tasks) > 0
+            else 0
+        )
 
     def average_gc_time(self):
-        return sum([t.gc_time for t in self.tasks]) * 1.0 / len(self.tasks) if len(self.tasks) > 0 else 0
+        return (
+            sum([t.gc_time for t in self.tasks]) * 1.0 / len(self.tasks)
+            if len(self.tasks) > 0
+            else 0
+        )
 
     def total_gc_time(self):
-        return sum([t.gc_time for t in self.tasks]) 
+        return sum([t.gc_time for t in self.tasks])
 
     def has_shuffle_read(self):
         total_shuffle_read_bytes = sum(
-            [t.remote_mb_read + t.local_mb_read for t in self.tasks if t.has_fetch])
+            [t.remote_mb_read + t.local_mb_read for t in self.tasks if t.has_fetch]
+        )
         return total_shuffle_read_bytes > 0
 
     def conservative_finish_time(self):
@@ -52,7 +87,7 @@ class StageModel:
         return max([(t.finish_time - t.scheduler_delay) for t in self.tasks])
 
     def finish_time(self):
-        return max([t.finish_time for t in self.tasks], default=0)   
+        return max([t.finish_time for t in self.tasks], default=0)
 
     def total_runtime(self):
         return sum([t.finish_time - t.start_time for t in self.tasks])
@@ -61,34 +96,38 @@ class StageModel:
         return sum([t.fetch_wait for t in self.tasks if t.has_fetch])
 
     def total_remote_blocks_read(self):
-        return sum([t.remote_blocks_read for t in self.tasks if t.has_fetch])     
+        return sum([t.remote_blocks_read for t in self.tasks if t.has_fetch])
 
     def total_remote_mb_read(self):
-        return sum([t.remote_mb_read for t in self.tasks if t.has_fetch])     
+        return sum([t.remote_mb_read for t in self.tasks if t.has_fetch])
 
     def total_write_time(self):
         return sum([t.shuffle_write_time for t in self.tasks])
-        
+
     def total_memory_bytes_spilled(self):
         return sum([t.memory_bytes_spilled for t in self.tasks])
 
     def total_disk_bytes_spilled(self):
-        return sum([t.disk_bytes_spilled for t in self.tasks]) 
+        return sum([t.disk_bytes_spilled for t in self.tasks])
 
     def total_result_size(self):
-        return sum([t.result_size for t in self.tasks])               
+        return sum([t.result_size for t in self.tasks])
 
     def max_disk_bytes_spilled(self):
-        return max([t.disk_bytes_spilled for t in self.tasks])      
+        return max([t.disk_bytes_spilled for t in self.tasks])
 
     def max_memory_bytes_spilled(self):
-        return max([t.memory_bytes_spilled for t in self.tasks]) 
-  
+        return max([t.memory_bytes_spilled for t in self.tasks])
+
     def max_task_runtime(self):
-        return numpy.percentile([t.compute_time() for t in self.tasks], 100) if len(self.tasks) > 0 else 0          
+        return (
+            numpy.percentile([t.compute_time() for t in self.tasks], 100)
+            if len(self.tasks) > 0
+            else 0
+        )
 
     def max_peak_execution_memory(self):
-        return max([t.peak_execution_memory for t in self.tasks]) 
+        return max([t.peak_execution_memory for t in self.tasks])
 
     def total_runtime_no_remote_shuffle_read(self):
         return sum([t.runtime_no_remote_shuffle_read() for t in self.tasks])
@@ -97,16 +136,18 @@ class StageModel:
         return sum([t.total_time_fetching for t in self.tasks if t.has_fetch])
 
     def input_mb(self):
-        """ Returns the total input size for this stage.
+        """Returns the total input size for this stage.
 
         This is only valid if the stage read data from a shuffle.
         """
-        total_input_bytes = sum([t.remote_mb_read + t.local_mb_read for t in self.tasks if t.has_fetch])
+        total_input_bytes = sum(
+            [t.remote_mb_read + t.local_mb_read for t in self.tasks if t.has_fetch]
+        )
         total_input_bytes += sum([t.input_mb for t in self.tasks])
         return total_input_bytes
 
     def output_mb(self):
-        """ Returns the total output size for this stage.
+        """Returns the total output size for this stage.
 
         This is only valid if the output data was written for a shuffle.
         TODO: Add HDFS / in-memory RDD output size.
@@ -118,21 +159,68 @@ class StageModel:
         # TODO: account for failed tasks
         if "Task Metrics" in data:
             task = TaskModel(data, is_json)
+            self.add_task(task)
 
-            if self.start_time == -1:
-                self.start_time = task.start_time
-            else:
-                self.start_time = min(self.start_time, task.start_time)
+    def add_task(self, task: TaskModel):
+        if self.tasks_finalized:
+            raise RuntimeError(
+                "Attempted to add a task to a stage after that stage had already been finalized."
+            )
 
-            self.tasks.append(task)
+        if self.start_time == -1:
+            self.start_time = task.start_time
+        else:
+            self.start_time = min(self.start_time, task.start_time)
+
+        self.tasks.append(task)
+
+    def finalize_tasks(self):
+        """
+        Since tasks may be added to Stages out-of-order, this method should be called once we know we are done
+        processing all Tasks.
+        """
+        self.tasks_finalized = True
+        # When log lines are read in-order, SparkListenerTaskEnd lines will be present in the log ordered by their
+        # finish_time (but, if multiple Tasks end at the same time, the order they appear in the eventlog is
+        # non-deterministic). Since we receive the tasks out-of-order, we can just do a sort on them to put them
+        # in their "correct" order
+        self.tasks.sort(key=lambda t: t.finish_time)
 
     def get_features(self, stage_id):
-        """ Return features from stage to write to csv
-
+        """
+        Return features from stage to write to csv
         """
         features = []
         for t in self.tasks:
-            features.append([stage_id, t.executor_id, t.start_time, t.finish_time, t.executor, t.executor_run_time, t.executor_deserialize_time, t.result_serialization_time, t.gc_time, t.network_bytes_transmitted_ps, t.network_bytes_received_ps, t.process_cpu_utilization, t.total_cpu_utilization, t.shuffle_write_time, t.shuffle_mb_written, t.input_read_time, t.input_mb, t.output_mb, t.has_fetch, t.data_local, t.local_mb_read, t.local_read_time, t.total_time_fetching, t.remote_mb_read, t.scheduler_delay])
+            features.append(
+                [
+                    stage_id,
+                    t.executor_id,
+                    t.start_time,
+                    t.finish_time,
+                    t.executor,
+                    t.executor_run_time,
+                    t.executor_deserialize_time,
+                    t.result_serialization_time,
+                    t.gc_time,
+                    t.network_bytes_transmitted_ps,
+                    t.network_bytes_received_ps,
+                    t.process_cpu_utilization,
+                    t.total_cpu_utilization,
+                    t.shuffle_write_time,
+                    t.shuffle_mb_written,
+                    t.input_read_time,
+                    t.input_mb,
+                    t.output_mb,
+                    t.has_fetch,
+                    t.data_local,
+                    t.local_mb_read,
+                    t.local_read_time,
+                    t.total_time_fetching,
+                    t.remote_mb_read,
+                    t.scheduler_delay,
+                ]
+            )
 
         # print(features)
         return features

--- a/spark_log_parser/parsing_models/task_model.py
+++ b/spark_log_parser/parsing_models/task_model.py
@@ -1,54 +1,63 @@
-import numpy
 import logging
+
 
 class TaskModel:
     """
     Model for a task within a stage
     """
+
     def __init__(self, data, is_json):
         if is_json:
             self.initialize_from_json(data)
         else:
             self.initialize_from_job_logger(data)
 
-        self.scheduler_delay = (self.finish_time - self.executor_run_time -
-            self.executor_deserialize_time - self.result_serialization_time - self.start_time)
+        self.scheduler_delay = (
+            self.finish_time
+            - self.executor_run_time
+            - self.executor_deserialize_time
+            - self.result_serialization_time
+            - self.start_time
+        )
         # Should be set to true if this task is a straggler and we know the cause of the
         # straggler behavior.
         self.straggler_behavior_explained = False
-    
 
     def initialize_from_json(self, json_data):
-
         self.logger = logging.getLogger("Task")
 
         task_info = json_data["Task Info"]
-        
+
         task_metrics = json_data["Task Metrics"]
         if "Task Executor Metrics" in json_data:
             task_executor_metrics = json_data["Task Executor Metrics"]
         else:
             task_executor_metrics = None
 
-        self.start_time = task_info["Launch Time"]/1000 # [s]
-        self.finish_time = task_info["Finish Time"]/1000 # [s]
-        self.task_id     = task_info['Task ID']
+        self.stage_id = json_data["Stage ID"]
+        self.start_time = task_info["Launch Time"] / 1000  # [s]
+        self.finish_time = task_info["Finish Time"] / 1000  # [s]
+        self.task_id = task_info["Task ID"]
         self.executor = task_info["Host"]
-        self.killed     = task_info["Killed"]
-        self.speculative= task_info["Speculative"] # True if a duplicate task
-        self.executor_run_time = task_metrics["Executor Run Time"]/1000 # [ms --> s]
-        self.executor_cpu_time = task_metrics["Executor CPU Time"]/1000000000 # [ns --> s]
-        self.executor_deserialize_time = task_metrics["Executor Deserialize Time"]/1000 # [ms --> s]
-        self.result_serialization_time = task_metrics["Result Serialization Time"]/1000 # [ms --> s]#
-        self.gc_time = task_metrics["JVM GC Time"]/1000 # [s]
-        self.memory_bytes_spilled = task_metrics["Memory Bytes Spilled"]/1000000 # [MB]
-        self.disk_bytes_spilled = task_metrics["Disk Bytes Spilled"]/1000000 # [MB]
-        self.result_size = task_metrics["Result Size"]/1000000 # [MB]
+        self.killed = task_info["Killed"]
+        self.speculative = task_info["Speculative"]  # True if a duplicate task
+        self.executor_run_time = task_metrics["Executor Run Time"] / 1000  # [ms --> s]
+        self.executor_cpu_time = task_metrics["Executor CPU Time"] / 1000000000  # [ns --> s]
+        self.executor_deserialize_time = (
+            task_metrics["Executor Deserialize Time"] / 1000
+        )  # [ms --> s]
+        self.result_serialization_time = (
+            task_metrics["Result Serialization Time"] / 1000
+        )  # [ms --> s]#
+        self.gc_time = task_metrics["JVM GC Time"] / 1000  # [s]
+        self.memory_bytes_spilled = task_metrics["Memory Bytes Spilled"] / 1000000  # [MB]
+        self.disk_bytes_spilled = task_metrics["Disk Bytes Spilled"] / 1000000  # [MB]
+        self.result_size = task_metrics["Result Size"] / 1000000  # [MB]
         if "Peak Execution Memory" in task_metrics:
-            self.peak_execution_memory = task_metrics["Peak Execution Memory"]/1000000 # [MB]
+            self.peak_execution_memory = task_metrics["Peak Execution Memory"] / 1000000  # [MB]
         else:
             self.peak_execution_memory = -1
-        # TODO: looks like this is never used.
+
         self.executor_id = task_info["Executor ID"]
 
         # TODO: add utilization to task metrics output by JSON.
@@ -66,7 +75,7 @@ class TaskModel:
 
         SHUFFLE_WRITE_METRICS_KEY = "Shuffle Write Metrics"
         if SHUFFLE_WRITE_METRICS_KEY in task_metrics:
-            shuffle_write_metrics = task_metrics[SHUFFLE_WRITE_METRICS_KEY] 
+            shuffle_write_metrics = task_metrics[SHUFFLE_WRITE_METRICS_KEY]
             # Convert to s (from nanoseconds).
             self.shuffle_write_time = shuffle_write_metrics["Shuffle Write Time"] / 1.0e9
         OPEN_TIME_KEY = "Shuffle Open Time"
@@ -79,7 +88,7 @@ class TaskModel:
             shuffle_close_time = shuffle_write_metrics[CLOSE_TIME_KEY] / 1.0e9
             print("Shuffle close time: ", shuffle_close_time)
             self.shuffle_write_time += shuffle_close_time
-        self.shuffle_mb_written = shuffle_write_metrics["Shuffle Bytes Written"] / 1048576.
+        self.shuffle_mb_written = shuffle_write_metrics["Shuffle Bytes Written"] / 1048576.0
 
         # TODO: print warning when non-zero disk bytes spilled??
         # TODO: are these accounted for in shuffle metrics?
@@ -91,50 +100,54 @@ class TaskModel:
 
         if INPUT_METRICS_KEY in task_metrics:
             input_metrics = task_metrics[INPUT_METRICS_KEY]
-            self.input_read_time = 0 # TODO: fill in once input time has been added.
+            self.input_read_time = 0  # TODO: fill in once input time has been added.
             # self.input_read_method = input_metrics["Data Read Method"]
-            self.input_mb = input_metrics["Bytes Read"] / 1048576.
+            self.input_mb = input_metrics["Bytes Read"] / 1048576.0
 
         OUTPUT_METRICS_KEY = "Output Metrics"
-        self.output_mb, self.output_write_time = 0, 0 # TODO: fill in once output time has been added.
+        self.output_mb, self.output_write_time = (
+            0,
+            0,
+        )  # TODO: fill in once output time has been added.
 
         if OUTPUT_METRICS_KEY in task_metrics:
             output_metrics = task_metrics[OUTPUT_METRICS_KEY]
-            self.output_mb = int(output_metrics["Bytes Written"]) / 1048576.
-
+            self.output_mb = int(output_metrics["Bytes Written"]) / 1048576.0
 
         self.has_fetch = True
         # False if the task was a map task that did not run locally with its input data.
         self.data_local = True
         SHUFFLE_READ_METRICS_KEY = "Shuffle Read Metrics"
         if SHUFFLE_READ_METRICS_KEY not in task_metrics:
-            if (task_info["Locality"] != "NODE_LOCAL") and (task_info["Locality"] != "PROCESS_LOCAL"):
+            if (task_info["Locality"] != "NODE_LOCAL") and (
+                task_info["Locality"] != "PROCESS_LOCAL"
+            ):
                 self.data_local = False
             self.has_fetch = False
             return
 
         shuffle_read_metrics = task_metrics[SHUFFLE_READ_METRICS_KEY]
-        
-        self.fetch_wait = shuffle_read_metrics["Fetch Wait Time"]/1000 # [s]
+
+        self.fetch_wait = shuffle_read_metrics["Fetch Wait Time"] / 1000  # [s]
         self.local_blocks_read = shuffle_read_metrics["Local Blocks Fetched"]
         self.remote_blocks_read = shuffle_read_metrics["Remote Blocks Fetched"]
-        self.remote_mb_read = shuffle_read_metrics["Remote Bytes Read"] / 1048576.
+        self.remote_mb_read = shuffle_read_metrics["Remote Bytes Read"] / 1048576.0
         # if self.remote_mb_read > 0:
         #   print(f'remote mb read: {self.remote_mb_read}')
 
         self.local_mb_read = 0
         LOCAL_BYTES_READ_KEY = "Local Bytes Read"
         if LOCAL_BYTES_READ_KEY in shuffle_read_metrics:
-            self.local_mb_read = shuffle_read_metrics[LOCAL_BYTES_READ_KEY] / 1048576.
+            self.local_mb_read = shuffle_read_metrics[LOCAL_BYTES_READ_KEY] / 1048576.0
             # The local read time is not included in the fetch wait time: the task blocks
             # on reading data locally in the BlockFetcherIterator.initialize() method.
         self.local_read_time = 0
         LOCAL_READ_TIME_KEY = "Local Read Time"
         if LOCAL_READ_TIME_KEY in shuffle_read_metrics:
-            self.local_read_time = shuffle_read_metrics[LOCAL_READ_TIME_KEY]/1000 # [s]
-        self.total_time_fetching = shuffle_read_metrics["Fetch Wait Time"]/1000 # [s]
-            # if self.total_time_fetching > 0:
-            #   print(f'shuffle wait time: {self.total_time_fetching}')
+            self.local_read_time = shuffle_read_metrics[LOCAL_READ_TIME_KEY] / 1000  # [s]
+        self.total_time_fetching = shuffle_read_metrics["Fetch Wait Time"] / 1000  # [s]
+        # if self.total_time_fetching > 0:
+        #   print(f'shuffle wait time: {self.total_time_fetching}')
         if task_executor_metrics is not None:
             self.jvm_heap_memory = task_executor_metrics["JVMHeapMemory"]
             self.jvm_offheap_memory = task_executor_metrics["JVMOffHeapMemory"]
@@ -163,7 +176,7 @@ class TaskModel:
             self.python_rss_memory = 0
             self.other_v_memory = 0
             self.other_rss_memory = 0
-            
+
     def input_size_mb(self):
         if self.has_fetch:
             return self.remote_mb_read + self.local_mb_read
@@ -171,13 +184,19 @@ class TaskModel:
             return self.input_mb
 
     def compute_time_without_gc(self):
-        """ Returns the time this task spent computing.
-        
+        """Returns the time this task spent computing.
+
         Assumes shuffle writes don't get pipelined with task execution (TODO: verify this).
         Does not include GC time.
         """
-        compute_time = (self.runtime() - self.scheduler_delay - self.gc_time -
-        self.shuffle_write_time - self.input_read_time - self.output_write_time)
+        compute_time = (
+            self.runtime()
+            - self.scheduler_delay
+            - self.gc_time
+            - self.shuffle_write_time
+            - self.input_read_time
+            - self.output_write_time
+        )
         if self.has_fetch:
             # Subtract off of the time to read local data (which typically comes from disk) because
             # this read happens before any of the computation starts.
@@ -185,7 +204,7 @@ class TaskModel:
         return compute_time
 
     def compute_time(self):
-        """ Returns the time this task spent computing (potentially including GC time).
+        """Returns the time this task spent computing (potentially including GC time).
 
         The reason we don't subtract out GC time here is that garbage collection may happen
         during fetch wait.
@@ -194,9 +213,12 @@ class TaskModel:
 
     # Added by SDG 4/30/2021 for further breakdown of "compute" time
     def task_compute_time(self):
-        task_compute_time = (self.compute_time_without_gc() - self.executor_deserialize_time
-        - self.result_serialization_time)
-        
+        task_compute_time = (
+            self.compute_time_without_gc()
+            - self.executor_deserialize_time
+            - self.result_serialization_time
+        )
+
         return task_compute_time
 
     def runtime(self):
@@ -208,6 +230,10 @@ class TaskModel:
 
     def runtime_no_output(self):
         new_finish_time = self.finish_time - self.output_write_time
+        return new_finish_time - self.start_time
+
+    def runtime_no_input_or_output(self):
+        new_finish_time = self.finish_time - self.input_read_time - self.output_write_time
         return new_finish_time - self.start_time
 
     def runtime_no_shuffle_write(self):
@@ -225,14 +251,6 @@ class TaskModel:
         else:
             return self.runtime()
 
-    def runtime_no_output(self):
-        new_finish_time = self.finish_time - self.output_write_time
-        return new_finish_time - self.start_time
-
-    def runtime_no_input_or_output(self):
-        new_finish_time = self.finish_time - self.input_read_time - self.output_write_time
-        return new_finish_time - self.start_time
-
     def runtime_no_network(self):
         runtime_no_in_or_out = self.runtime_no_output()
         if not self.data_local:
@@ -241,4 +259,3 @@ class TaskModel:
             return runtime_no_in_or_out - self.fetch_wait
         else:
             return runtime_no_in_or_out
-


### PR DESCRIPTION
Addresses - https://synccomputing.atlassian.net/browse/PROD-582

This change updates `ApplicationModel` to not expect to receive eventlog lines in any particular order (which it does today). This is important to support as we move towards a model where we may not have all of the eventlog files available on-disk (i.e. we are streaming them directly from some other server) and thus can't guarantee that lines will be received in any particular order.

In order to test these changes, I -

- Generated a Prediction using the log parsing logic as-is;
- Re-parsed the raw eventlog using this branch;
- Generated a new Prediction using the newly parsed log;
- Ensured that the predictions were the same (minus some rounding errors in float values)

I did this for a few of the test log files we have in this repository, and also for some eventlogs that have triggered specific bugs in the parser in the past (https://synccomputing.atlassian.net/browse/SPC-213 & https://synccomputing.atlassian.net/browse/PROD-426, mostly)

In order to test the out-of-order nature, I read the whole raw eventlog into memory and then just shuffled those lines prior to building the application model. I.e. just -

```python
log_lines = [line for line in f]
random.shuffle(log_lines)

for line in log_lines:
    ...
```

In practice, until other changes around using `DataLoader`s land, we will still be reading log lines in-order.