### PR TITLE
PROD-611 Disambiguate parsed vs. unparsed logs without parsing the file multiple times

### DIFF
--- a/spark_log_parser/loaders/__init__.py
+++ b/spark_log_parser/loaders/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 from io import BufferedIOBase
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, TypeVar
 from urllib.parse import ParseResult
 
 from pydantic import BaseModel
@@ -123,6 +123,10 @@ class ZipArchiveMemberStreamWrapper(FileChunkStreamWrapper):
     """Just an alias for FileChunkStreamWrapper for use when extracting Zip archive members using stream-unzip"""
 
 
+FileStreamIterator = TypeVar("FileStreamIterator", bound=Iterator[bytes])
+FileExtractionResult = TypeVar("FileExtractionResult", bound=tuple[Path, FileStreamIterator])
+
+
 class AbstractFileDataLoader(DataLoader, abc.ABC):
     """
     Base class for loading files over various transport mechanisms. This commits to streaming file data as much as
@@ -161,7 +165,7 @@ class AbstractFileDataLoader(DataLoader, abc.ABC):
         filename = filename.lower()
         return any([name in filename for name in FILE_SKIP_PATTERNS])
 
-    def read_tgz_archive(self, archive: tarfile.TarFile) -> Iterator[bytes]:
+    def read_tgz_archive(self, archive: tarfile.TarFile) -> Iterator[FileExtractionResult]:
         """
         Utility for unpacking a tarball, asserting that the contents of that tarball fall within our file-size
         constraints
@@ -185,7 +189,7 @@ class AbstractFileDataLoader(DataLoader, abc.ABC):
 
             size_left -= wrapped_bytes.total_size
 
-    def read_zip_archive(self, raw_archive_stream) -> Iterator[bytes]:
+    def read_zip_archive(self, raw_archive_stream) -> Iterator[FileExtractionResult]:
         """
         Utility for unpacking a zip archive, asserting that the contents of that archive fall within our file-size
         constraints
@@ -221,27 +225,28 @@ class AbstractFileDataLoader(DataLoader, abc.ABC):
             #  untrusted/user input
             size_left -= wrapped_bytes.total_size
 
-    def extract_directory(self, directory: Path) -> Iterator[bytes]:
+    def extract_directory(self, directory: Path) -> Iterator[FileExtractionResult]:
         for path in directory.iterdir():
             yield from self.extract(path)
 
     @staticmethod
     @abc.abstractmethod
-    def read_file_stream(file: FileChunkStreamWrapper) -> Iterator[bytes]:
+    def read_file_stream(file: FileChunkStreamWrapper) -> FileStreamIterator:
         """
         This method will be called once we have reached a file that is fully uncompressed/untarred/etc.
         This is intended to allow concrete classes to have flexibility in the manner in which they yield data from the
         underlying file stream, whether that be raw chunks, lines, or as an entire blob (or something else entirely!)
         """
 
-    def extract(self, filepath: Path, file_stream: BufferedIOBase = None) -> Iterator[bytes]:
+    def extract(self, filepath: Path, file_stream: BufferedIOBase = None) -> Iterator[FileExtractionResult]:
         """
-        This method takes a filepath and potentially an already-open file_stream (if the filepath cannot be found
-        locally, the file_stream *must* be provided). Returns an Iterator of the underlying bytes of the file that
-        is fully decompressed/unzipped/untarred/etc., and ready to be parsed into some useful representation.
+        This method recursively extracts the contents of the file at the given filepath. If an open file_stream is
+        also provided, that file_stream will be operated on instead.
 
-        For archives, this Iterator will contain the bytes of all files present, except those that may be skipped (as
-        defined in should_skip_file()).
+        This method will ultimately return a sequence of tuples where the first item is the Path of the file that is
+        currently open (if we are extracting an archive/directory, then this will be the name of the file within
+        that location, not the name of the archive/directory itself), and the 2nd item is an Iterator of the bytes in
+        that file.
         """
         if file_stream is None and filepath.is_dir():
             yield from self.extract_directory(filepath)
@@ -276,7 +281,7 @@ class AbstractFileDataLoader(DataLoader, abc.ABC):
                     # We may see files like {name}.zip.gz/.json.gz, so make sure we handle that appropriately
                     if len(suffixes) == 1:
                         wrapped = FileChunkStreamWrapper(file)
-                        yield from self.read_file_stream(wrapped)
+                        yield filepath, self.read_file_stream(wrapped)
                     else:
                         new_path = Path(str(filepath).removesuffix(".gz"))
                         yield from self.extract(new_path, file)
@@ -286,17 +291,18 @@ class AbstractFileDataLoader(DataLoader, abc.ABC):
                 logger.info(f"Yielding raw file: {filepath}")
                 if file_stream:
                     wrapped = FileChunkStreamWrapper(file_stream)
-                    yield from self.read_file_stream(wrapped)
+                    yield filepath, self.read_file_stream(wrapped)
+
                 else:
                     with open(filepath, "rb") as file:
                         wrapped = FileChunkStreamWrapper(file)
-                        yield from self.read_file_stream(wrapped)
+                        yield filepath, self.read_file_stream(wrapped)
 
             case _:
                 raise ValueError(f"Unknown file format {''.join(filepath.suffixes)}")
 
     @abc.abstractmethod
-    def load_item(self, filepath: str | ParseResult) -> Iterator[bytes]:
+    def load_item(self, filepath: str | ParseResult) -> Iterator[FileExtractionResult]:
         """
         Since the concrete Loader may be fetching data from disparate data sources, this method should be
         responsible for grabbing the raw data stream for each file that may then be passed to extract().
@@ -305,7 +311,7 @@ class AbstractFileDataLoader(DataLoader, abc.ABC):
         will suffice
         """
 
-    async def batch_load_fn(self, keys: list[str]) -> list[Iterator[bytes]]:
+    async def batch_load_fn(self, keys: list[str]) -> list[Iterator[FileExtractionResult]]:
         return [self.load_item(filepath) for filepath in keys]
 
 

--- a/spark_log_parser/loaders/__init__.py
+++ b/spark_log_parser/loaders/__init__.py
@@ -150,8 +150,8 @@ class AbstractFileDataLoader(DataLoader, abc.ABC):
 
     _extraction_thresholds: ArchiveExtractionThresholds
 
-    def __init__(self, extraction_thresholds: ArchiveExtractionThresholds = None):
-        super().__init__()
+    def __init__(self, extraction_thresholds: ArchiveExtractionThresholds = None, **kwargs):
+        super().__init__(**kwargs)
         self._extraction_thresholds = extraction_thresholds or ArchiveExtractionThresholds()
 
     @staticmethod

--- a/spark_log_parser/loaders/json.py
+++ b/spark_log_parser/loaders/json.py
@@ -1,6 +1,6 @@
 import logging
 import orjson
-from typing import Generic, TypeVar, Iterator
+from typing import Generic, TypeVar
 
 from aiodataloader import DataLoader
 
@@ -21,10 +21,14 @@ class JSONBlobDataLoader(DataLoader, Generic[RawJSONBlobDataLoader]):
         super().__init__(**kwargs)
         self.blob_data_loader = blob_data_loader
 
+    def yield_json(self, data):
+        _, blob = data
+        return orjson.loads(next(blob))
+
     async def batch_load_fn(self, keys):
         raw_datas = await self.blob_data_loader.load_many(keys)
         # We expect each "blob" here to be well-formed JSON, so parse each of them thusly
-        return [orjson.loads(next(raw_data)) for raw_data in raw_datas]
+        return [self.yield_json(next(raw_data)) for raw_data in raw_datas]
 
 
 RawJSONLinesDataLoader = TypeVar("LinesDataLoader", LocalFileLinesDataLoader, S3FileLinesDataLoader,
@@ -36,25 +40,39 @@ class JSONLinesDataLoader(DataLoader, Generic[RawJSONLinesDataLoader]):
     lines_data_loader: RawJSONLinesDataLoader
 
     @staticmethod
-    def yield_json_lines(filename, lines) -> Iterator[str]:
-        num_bad_lines_seen = 0
-        for line in lines:
-            try:
-                yield orjson.loads(line)
-            # Note - this is largely here because we may get arbitrary file types in archives where we are
-            #  expecting eventlog files (which are JSON Lines). If we try to load those "lines" as
-            #  JSON objects, they will fail, and so this allows us to just skip those "bad" lines and
-            #  continue processing other files in the archive. However, this `except` could maybe be
-            #  more robust so that we aren't ignoring real issues! If we do encounter some bad lines,
-            #  we will at the very least log how many we hit
-            except orjson.JSONDecodeError:
-                num_bad_lines_seen += 1
-                # We have to continue here because these will be the lines for the top-level file. If this is an
-                #  archive, then it is possible for some lines to not be parse-able as JSON, but for others to be
-                continue
+    def yield_json_lines(data):
+        for filepath, file in data:
+            logger.info(f"Processing: {filepath}")
 
-        if num_bad_lines_seen > 0:
-            logger.info(f"Failed to parse {num_bad_lines_seen} JSON lines in top-level file: {filename}")
+            lines = iter(file)
+            first_line = next(lines)
+            try:
+                json_line = orjson.loads(first_line)
+                yield json_line
+            except orjson.JSONDecodeError:
+                # If the first line is not parseable as a JSON object, try to parse the whole file as a JSON Object
+                #  as well, and yield that as a line instead.
+                # We do this for a few reasons -
+                #  - Sometimes regular JSON files are delivered in archives along with eventlog files (which are JSON
+                #     Lines). These JSON files may contain valuable information that we don't want to drop on the floor
+                #     (for example, we may receive Databricks pricing information, which we may be able to use!)
+                #  - We may not be able to tell without opening the file whether the eventlog provided to us is a "raw"
+                #     eventlog (i.e. delivered to us in exactly the way Spark output them), or if it is an
+                #     already-parsed log.
+                #
+                # This means that, in a sense, we treat regular JSON files as a special case of JSON Lines files
+                for line in lines:
+                    first_line += line
+
+                try:
+                    yield orjson.loads(first_line)
+                except orjson.JSONDecodeError:
+                    logger.warning(f"Could not parse file {filepath} as JSON - skipping")
+                finally:
+                    continue
+
+            for line in lines:
+                yield orjson.loads(line)
 
     def __init__(self, lines_data_loader: RawJSONLinesDataLoader, **kwargs):
         super().__init__(**kwargs)
@@ -62,4 +80,4 @@ class JSONLinesDataLoader(DataLoader, Generic[RawJSONLinesDataLoader]):
 
     async def batch_load_fn(self, keys):
         raw_datas = await self.lines_data_loader.load_many(keys)
-        return [self.yield_json_lines(key, data) for (key, data) in zip(keys, raw_datas)]
+        return [self.yield_json_lines(data) for data in raw_datas]

--- a/spark_log_parser/loaders/json.py
+++ b/spark_log_parser/loaders/json.py
@@ -23,14 +23,14 @@ class JSONBlobDataLoader(DataLoader):
         self.blob_data_loader = blob_data_loader
 
     @staticmethod
-    def _yield_json(data):
+    def _parse_as_json(data: FileExtractionResult):
         _, blob = data
         return orjson.loads(next(blob))
 
     async def batch_load_fn(self, keys):
         raw_datas = await self.blob_data_loader.load_many(keys)
         # We expect each "blob" here to be well-formed JSON, so parse each of them thusly
-        return [self._yield_json(next(raw_data)) for raw_data in raw_datas]
+        return [self._parse_as_json(next(raw_data)) for raw_data in raw_datas]
 
 
 RawJSONLinesDataLoader = TypeVar("LinesDataLoader", LocalFileLinesDataLoader, S3FileLinesDataLoader,

--- a/spark_log_parser/loaders/s3.py
+++ b/spark_log_parser/loaders/s3.py
@@ -4,22 +4,7 @@ import boto3
 from pathlib import Path
 from urllib.parse import ParseResult, urlparse
 
-from botocore.response import StreamingBody
-
-from spark_log_parser.loaders import AbstractFileDataLoader, BlobFileReaderMixin, LinesFileReaderMixin, \
-    FileChunkStreamWrapper
-
-
-class S3StreamingBodyFileWrapper(FileChunkStreamWrapper):
-    """
-    Small wrapper around botocore.StreamingBody that exposes a lines iterator, in keeping with "pythonic" conventions.
-    botocore.StreamingBody by default iterates over raw chunks of the input stream vs. in a line-delimited manner. This
-    makes some sense, in general, since large files may not have newlines to split on. But as we expect to largely be
-    dealing with line-delimited eventlog files, this default makes more sense for us to use.
-    """
-
-    def __init__(self, body: StreamingBody, **kwargs):
-        super().__init__(**kwargs, chunks=body.iter_chunks(chunk_size=1024 * 1024))
+from spark_log_parser.loaders import AbstractFileDataLoader, BlobFileReaderMixin, LinesFileReaderMixin
 
 
 class AbstractS3FileDataLoader(AbstractFileDataLoader, abc.ABC):
@@ -28,9 +13,6 @@ class AbstractS3FileDataLoader(AbstractFileDataLoader, abc.ABC):
     """
 
     _s3 = None
-
-    def __init__(self):
-        super().__init__()
 
     @property
     def s3(self):
@@ -71,8 +53,7 @@ class AbstractS3FileDataLoader(AbstractFileDataLoader, abc.ABC):
             # Wrap the botocore.response.StreamingBody and return that so that subsequent extraction can operate on the
             #  stream vs. loading all the files into memory
             data = self.s3.get_object(Bucket=bucket, Key=content["Key"])["Body"]
-            wrapped = S3StreamingBodyFileWrapper(data)
-            file_streams.append(wrapped)
+            file_streams.append(data)
 
         for (content, filestream) in zip(contents_to_fetch, file_streams):
             yield from self.extract(Path(content["Key"]), filestream)

--- a/spark_log_parser/parsing_models/application_model.py
+++ b/spark_log_parser/parsing_models/application_model.py
@@ -4,7 +4,7 @@ from typing import Iterator
 import numpy
 
 from .dag_model import DagModel
-from .exceptions import UrgentEventValidationException, LogSubmissionException
+from .exceptions import UrgentEventValidationException, LogSubmissionException, LazyEventValidationException
 from .executor_model import ExecutorModel
 from .job_model import JobModel
 from .stage_model import StageModel
@@ -241,15 +241,18 @@ class ApplicationModel:
             expected_rollover_log_numbers_seen = set(range(max_rollover + 1))
             if expected_rollover_log_numbers_seen.difference(rollover_log_numbers_seen):
                 raise LogSubmissionException(
-                    error_message=("Rollover logs were detected, but there were fewer than expected.\n" +
-                                   f"Expected to receive rollover numbers: {', '.join(expected_rollover_log_numbers_seen)}, " +
-                                   f"but instead received: {', '.join(sorted(rollover_log_numbers_seen))} ")
+                    error_message=("Rollover logs were detected, but there were fewer than expected.\n"
+                                   + f"Expected to receive rollover numbers: {', '.join(expected_rollover_log_numbers_seen)}, "
+                                   + f"but instead received: {', '.join(sorted(rollover_log_numbers_seen))} ")
                 )
 
         for task in self.tasks:
             stage_id = task.stage_id
             stage = self.stages[stage_id]
             stage.add_task(task)
+
+        if len(self.stages) == 0:
+            raise LazyEventValidationException("No stages detected in Spark Eventlog")
 
         for stage_id, stage in self.stages.items():
             if stage.submission_time is None:

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -15,7 +15,6 @@ import pandas as pd
 from aiodataloader import DataLoader
 
 from .application_model import ApplicationModel
-from .exceptions import SyncParserException
 from .validation_configs import ConfigValidationDatabricks, ConfigValidationEMR
 from .validation_event_data import EventDataValidation
 from ..loaders import ArchiveExtractionThresholds
@@ -23,6 +22,8 @@ from ..loaders.https import HTTPFileLinesDataLoader
 from ..loaders.json import JSONBlobDataLoader, JSONLinesDataLoader
 from ..loaders.local_file import LocalFileLinesDataLoader
 from ..loaders.s3 import S3FileLinesDataLoader
+
+logger = logging.getLogger("SparkApplication")
 
 
 class SparkApplication:
@@ -95,7 +96,7 @@ class SparkApplication:
         elif compress is True:
             with gzip.open(filepath + ".json.gz", "w") as fout:
                 fout.write(json.dumps(saveDat).encode("ascii"))
-        logging.info("Saved object locally to: %s" % (filepath))
+        logger.info("Saved object locally to: %s" % (filepath))
 
     def save_to_s3(self, saveDat, filepath, compress):
         s3 = boto3.client("s3")
@@ -111,76 +112,125 @@ class SparkApplication:
             dat = gzip.compress(json.dumps(saveDat).encode("utf-8"))
             s3.put_object(Bucket=bucket, Body=dat, Key=key + ".gz")
 
-        logging.info("Saved object to cloud: %s" % (key))
+        logger.info("Saved object to cloud: %s" % (key))
 
 
-DataType = TypeVar("DataType")
+SparkApplicationRawDataType = TypeVar("DataType")
+SparkApplicationLoaderKey = TypeVar("SparkApplicationLoaderKey")
 
 
-class AbstractSparkApplicationDataLoader(abc.ABC, Generic[DataType], DataLoader):
+class AbstractSparkApplicationDataLoader(abc.ABC,
+                                         Generic[SparkApplicationLoaderKey, SparkApplicationRawDataType],
+                                         DataLoader):
     """
     Defines the methods that other data loaders should implement in order to appropriately construct
-    some SparkApplication. The order in which these methods are called is defined in construct_spark_application
+    some SparkApplication. The order in which these methods are called is defined in construct_spark_application.
     """
 
     @abc.abstractmethod
-    async def load_raw_datas(self, keys) -> list[DataType]:
+    async def load_raw_datas(self, keys: list[SparkApplicationLoaderKey]) -> list[SparkApplicationRawDataType]:
         """
-        Method that should return the data that is our "source-of-truth" (i.e. that data from which we will be
-        constructing the SparkApplication)
+        Implementors of this method should return the data that will be the "source-of-truth", i.e. that data from
+        which this concrete class will be constructing the SparkApplication.
         """
 
     @abc.abstractmethod
-    def compute_sql_info(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
-        """ TODO """
+    def init_spark_application(self, raw_data: SparkApplicationRawDataType) -> SparkApplication:
+        """
+        Allows subclasses to provide their own instance of SparkApplication (or some sub-class)
+        """
+        return SparkApplication()
+
+    @abc.abstractmethod
+    def compute_sql_info(self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication) -> SparkApplication:
+        """
+        This method is responsible for setting the following fields on spark_app:
+
+            - existsSQL
+            - sqlData
+        """
 
     @abc.abstractmethod
     def compute_executor_info(
-        self, raw_data: DataType, spark_app: SparkApplication
+        self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication
     ) -> SparkApplication:
-        """ TODO """
+        """
+        This method is responsible for setting the following fields on spark_app:
+
+            - existsExecutors
+            - executorData
+        """
 
     @abc.abstractmethod
     def compute_all_job_data(
-        self, raw_data: DataType, spark_app: SparkApplication
+        self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication
     ) -> SparkApplication:
-        """ TODO """
+        """
+        This method is responsible for setting the following fields on spark_app:
 
-    @abc.abstractmethod
-    def compute_all_task_data(
-        self, raw_data: DataType, spark_app: SparkApplication
-    ) -> SparkApplication:
-        """ TODO """
+            - jobData
+        """
 
     @abc.abstractmethod
     def compute_all_stage_data(
-        self, raw_data: DataType, spark_app: SparkApplication
+        self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication
     ) -> SparkApplication:
-        """ TODO """
+        """
+        This method is responsible for setting the following fields on spark_app:
+
+            - stageData
+        """
+
+    @abc.abstractmethod
+    def compute_all_task_data(
+        self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication
+    ) -> SparkApplication:
+        """
+        This method is responsible for setting the following fields on spark_app:
+
+            - taskData
+        """
 
     @abc.abstractmethod
     def compute_all_driver_accum_data(
-        self, raw_data: DataType, spark_app: SparkApplication
+        self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication
     ) -> SparkApplication:
-        """ TODO """
+        """
+        This method is responsible for setting the following fields on spark_app:
+
+            - accumData
+        """
 
     @abc.abstractmethod
     def compute_all_metadata(
-        self, raw_data: DataType, spark_app: SparkApplication
+        self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication
     ) -> SparkApplication:
-        """ TODO """
+        """
+        This method is responsible for setting the following fields on spark_app:
+
+            - metadata
+        """
 
     @abc.abstractmethod
     def compute_recent_events(
-        self, raw_data: DataType, spark_app: SparkApplication
+        self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication
     ) -> SparkApplication:
-        """ TODO """
+        """
+        This method is responsible for updating the "time_since_last_event" value on both:
 
-    def construct_spark_application(self, raw_data) -> SparkApplication:
+            - spark_app.stageData
+            - spark_app.sqlData
+
+        This value should be a list of timestamps where each timestamp is the most recent Task or SQL event
+        to complete before this stage/SQL event started executing.
+        """
+
+    def construct_spark_application(self, key: SparkApplicationLoaderKey,
+                                    raw_data: SparkApplicationRawDataType) -> SparkApplication:
         """
         Generic 'recipe' for constructing a SparkApplication from some raw source of data.
         """
-        spark_app = SparkApplication()
+        spark_app = self.init_spark_application()
         spark_app = self.compute_sql_info(raw_data, spark_app)
         spark_app = self.compute_executor_info(raw_data, spark_app)
         spark_app = self.compute_all_job_data(raw_data, spark_app)
@@ -191,12 +241,12 @@ class AbstractSparkApplicationDataLoader(abc.ABC, Generic[DataType], DataLoader)
         spark_app = self.compute_recent_events(raw_data, spark_app)
         return spark_app
 
-    async def batch_load_fn(self, keys):
+    async def batch_load_fn(self, keys: list[SparkApplicationLoaderKey]):
         raw_datas = await self.load_raw_datas(keys)
-        return [self.construct_spark_application(k) for k in raw_datas]
+        return [self.construct_spark_application(*kv) for kv in zip(keys, raw_datas)]
 
 
-class ParsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[dict]):
+class ParsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[str, dict]):
     """
     Creates a SparkApplication from a parsed JSON representation of that application. Useful for re-hydrating
     parsed logs that were saved somewhere (or submitted directly to us)
@@ -214,6 +264,9 @@ class ParsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[dict]):
         Loads many already-parsed eventlogs from the provided filepaths
         """
         return await self._json_data_loader.load_many(keys)
+
+    def init_spark_application(self, raw_data) -> SparkApplication:
+        return super().init_spark_application(raw_data)
 
     def compute_recent_events(
         self, raw_data: dict, spark_app: SparkApplication
@@ -297,7 +350,7 @@ class ParsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[dict]):
         return spark_app
 
 
-class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[ApplicationModel]):
+class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[str, ApplicationModel]):
     """
     From a raw set of Spark log lines, constructs a SparkApplication
     """
@@ -336,8 +389,11 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
         val2 = EventDataValidation(app=app_model)
         val2.validate()
 
-    async def load_raw_datas(self, keys) -> list[ApplicationModel]:
-        """ """
+    async def load_raw_datas(self, keys: list[str]) -> list[ApplicationModel]:
+        """
+        Returns a list of ApplicationModels, provided some keys pointing to some raw eventlog file locations. These
+        models have not yet been validated, since we are loading the "raw" data here.
+        """
         if self._json_lines_loader is None:
             raise RuntimeError("Instance was initialized without a json_lines_loader, and therefore can't be used "
                                + "to load raw data.")
@@ -346,11 +402,11 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
 
         app_models = [ApplicationModel(log_lines=raw_data) for raw_data in raw_datas]
 
-        for app_model in app_models:
-            # TODO - probably somewhere better to put this?..
-            self.validate_app_model(app_model)
-
         return app_models
+
+    def init_spark_application(self, raw_data: ApplicationModel) -> SparkApplication:
+        self.validate_app_model(raw_data)
+        return super().init_spark_application(raw_data)
 
     def compute_sql_info(
         self, raw_data: ApplicationModel, spark_app: SparkApplication
@@ -358,7 +414,7 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
         # Get sql info if it exists
         app_model = raw_data
         if not (hasattr(app_model, "sql") and app_model.sql):
-            logging.warning("No sql attribute found.")
+            logger.warning("No sql attribute found.")
             spark_app.existsSQL = False
             return spark_app
 
@@ -380,7 +436,7 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
                     job.submission_time <= sql["end_time"]
                 ):
                     if "completion_time" not in job.__dict__:
-                        logging.debug(
+                        logger.debug(
                             f"Job {jid} missing completion time. Substituting with associated SQL {sqlid} completion time"
                         )
                         job.completion_time = sql["end_time"]
@@ -418,7 +474,7 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
     ) -> SparkApplication:
         app_model = raw_data
         if not (hasattr(app_model, "executors") and app_model.executors):
-            logging.warning("Executor attribute not found.")
+            logger.warning("Executor attribute not found.")
             return spark_app
 
         spark_app.existsExecutors = True
@@ -482,7 +538,7 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
                     for jid in row["job_ids"]:
                         df.at[jid, "sql_id"] = qid
 
-        logging.info("Aggregated job data [%.2f]" % (time.time() - t1))
+        logger.info("Aggregated job data [%.2f]" % (time.time() - t1))
 
         spark_app.jobData = df
 
@@ -656,7 +712,7 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
         )
 
         # Report timing and save the dataframe
-        logging.info("Aggregated task data [%.2fs]" % (time.time() - t1))
+        logger.info("Aggregated task data [%.2fs]" % (time.time() - t1))
         spark_app.taskData = df
         return spark_app
 
@@ -809,7 +865,7 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
             .set_index("stage_id")
         )
 
-        logging.info("Aggregated stage data [%.2fs]" % (time.time() - t1))
+        logger.info("Aggregated stage data [%.2fs]" % (time.time() - t1))
         spark_app.stageData = df
         return spark_app
 
@@ -841,7 +897,7 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
         # if not driver accum update values, then empty dataframe
         else:
             df = pd.DataFrame()
-        logging.info("Aggregated accum data [%.2fs]" % (time.time() - t1))
+        logger.info("Aggregated accum data [%.2fs]" % (time.time() - t1))
 
         spark_app.accumData = df
         return spark_app
@@ -906,17 +962,12 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
         return spark_app
 
 
-class AmbiguousLogFormatSparkApplicationLoader(AbstractSparkApplicationDataLoader[dict | ApplicationModel]):
-    """
-    Much of the time, we may not know whether a file given to us is for a parsed or unparsed eventlog without opening it
-    up first. But, we don't want to have to open up a file and just throw it away if it's not what we initially
-    expected. This class, then, may be used when this information is ambiguous to us, and it will handle calling into
-    the proper "sub-loader" transparently (and without having to re-load anything)
-    """
+class AbstractAmbiguousLogFormatSparkApplicationLoader(
+        AbstractSparkApplicationDataLoader[SparkApplicationLoaderKey, tuple[bool, dict | ApplicationModel]], abc.ABC):
 
-    _json_lines_loader: JSONLinesDataLoader
     _parsed_app_loader: ParsedLogSparkApplicationLoader
     _unparsed_app_loader: UnparsedLogSparkApplicationLoader
+    _json_lines_loader: JSONLinesDataLoader
 
     def __init__(
         self,
@@ -932,14 +983,25 @@ class AmbiguousLogFormatSparkApplicationLoader(AbstractSparkApplicationDataLoade
         self._parsed_app_loader = ParsedLogSparkApplicationLoader(None)
         self._unparsed_app_loader = UnparsedLogSparkApplicationLoader(None)
 
-    async def load_raw_datas(self, keys) -> list[DataType]:
+    def _construct_from_parsed_representation(self, key: str, data: tuple[bool, dict]):
+        return self._parsed_app_loader.construct_spark_application(key, data)
+
+    def _construct_from_unparsed_representation(self, key: str, data: tuple[bool, ApplicationModel]):
+        return self._unparsed_app_loader.construct_spark_application(key, data)
+
+    async def _load_raw_datas(self, keys: list[str]) -> list[tuple[bool, dict | ApplicationModel]]:
+        """
+        Given some eventlog locations, determines the data format of the file (i.e. raw vs already-parsed) and returns
+        the appropriate in-memory representation of that file.
+        """
         raw_datas = await self._json_lines_loader.load_many(keys)
 
         ret = []
-        for raw_data in raw_datas:
+        for key, raw_data in zip(keys, raw_datas):
             line = next(raw_data)
             # This assumes that for parsed apps, the first "line" from the file will be the fully-formed dictionary
-            #  representation of a SparkApplication. This may not be true over time...
+            #  representation of a SparkApplication. This may not be true over time... we should strive to keep this
+            #  check "cheap", however
             if SparkApplication.is_parsed_spark_app(line):
                 ret.append((True, line))
             else:
@@ -949,68 +1011,94 @@ class AmbiguousLogFormatSparkApplicationLoader(AbstractSparkApplicationDataLoade
                     yield line
                     yield from raw_data
 
-                app_model = ApplicationModel(log_lines=lines())
                 try:
-                    UnparsedLogSparkApplicationLoader.validate_app_model(app_model)
+                    app_model = ApplicationModel(log_lines=lines())
                     ret.append((False, app_model))
-                except SyncParserException as e:
-                    self.logger.warning(e)
+                except Exception as e:
+                    logger.error(f"Encountered an exception loading eventlog located at: {key}", exc_info=e)
                     ret.append((False, None))
 
         return ret
 
-    async def batch_load_fn(self, keys):
-        raw_datas = await self.load_raw_datas(keys)
+    def _construct_base_spark_application(self, key: str,
+                                          raw_data: tuple[bool, dict | ApplicationModel]) -> SparkApplication:
+        """
+        Given an initial piece of raw_data, calls into the appropriate "sub-loader" based on the detected file format,
+        i.e. whether the eventlog was delivered to us already-parsed.
+        """
+        is_parsed, data = raw_data
 
-        apps = []
-        for (is_parsed, data) in raw_datas:
-            # If we weren't able to create a SparkApplication out of one of the "keys" provided to us, we still need to
-            #  return something in order to adhere to the DataLoader batch API
-            if data is None:
-                spark_app = None
-            elif is_parsed:
-                spark_app = self._parsed_app_loader.construct_spark_application(data)
-            else:
-                spark_app = self._unparsed_app_loader.construct_spark_application(data)
+        # If we weren't able to create a SparkApplication out of one of the "keys" provided to us, we still need to
+        #  return something in order to adhere to the DataLoader batch API
+        if data is None:
+            spark_app = None
+        elif is_parsed:
+            spark_app = self._construct_from_parsed_representation(key, data)
+        else:
+            spark_app = self._construct_from_unparsed_representation(key, data)
 
-            apps.append(spark_app)
-
-        return apps
+        return spark_app
 
     # None of these abstract methods actually need to be implemented because we will be calling into the proper
     #  un/parsed SparkApplication loader based on the underlying data, and those loaders have these methods
     #  implemented already
-    def compute_sql_info(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+    def init_spark_application(self, raw_data) -> SparkApplication:
         """See comment above for why this is left un-implemented"""
         pass
 
-    def compute_executor_info(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+    def compute_sql_info(self, raw_data: SparkApplicationRawDataType, spark_app: SparkApplication) -> SparkApplication:
         """See comment above for why this is left un-implemented"""
         pass
 
-    def compute_all_job_data(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+    def compute_executor_info(self, raw_data: SparkApplicationRawDataType,
+                              spark_app: SparkApplication) -> SparkApplication:
         """See comment above for why this is left un-implemented"""
         pass
 
-    def compute_all_task_data(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+    def compute_all_job_data(self, raw_data: SparkApplicationRawDataType,
+                             spark_app: SparkApplication) -> SparkApplication:
         """See comment above for why this is left un-implemented"""
         pass
 
-    def compute_all_stage_data(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+    def compute_all_task_data(self, raw_data: SparkApplicationRawDataType,
+                              spark_app: SparkApplication) -> SparkApplication:
         """See comment above for why this is left un-implemented"""
         pass
 
-    def compute_all_driver_accum_data(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+    def compute_all_stage_data(self, raw_data: SparkApplicationRawDataType,
+                               spark_app: SparkApplication) -> SparkApplication:
         """See comment above for why this is left un-implemented"""
         pass
 
-    def compute_all_metadata(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+    def compute_all_driver_accum_data(self, raw_data: SparkApplicationRawDataType,
+                                      spark_app: SparkApplication) -> SparkApplication:
         """See comment above for why this is left un-implemented"""
         pass
 
-    def compute_recent_events(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+    def compute_all_metadata(self, raw_data: SparkApplicationRawDataType,
+                             spark_app: SparkApplication) -> SparkApplication:
         """See comment above for why this is left un-implemented"""
         pass
+
+    def compute_recent_events(self, raw_data: SparkApplicationRawDataType,
+                              spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
+        pass
+
+
+class AmbiguousLogFormatSparkApplicationLoader(AbstractAmbiguousLogFormatSparkApplicationLoader[str]):
+    """
+    Much of the time, we may not know whether a file given to us is for a parsed or unparsed eventlog without opening it
+    up first. But, we don't want to have to open up a file and just throw it away if it's not what we initially
+    expected. This class, then, may be used when this information is ambiguous to us, and it will handle calling into
+    the proper "sub-loader" transparently (and without having to re-load anything)
+    """
+
+    async def load_raw_datas(self, keys: list[str]) -> list[tuple[bool, dict | ApplicationModel]]:
+        return await self._load_raw_datas(keys)
+
+    def construct_spark_application(self, key: str, raw_data: tuple[bool, dict | ApplicationModel]) -> SparkApplication:
+        return self._construct_base_spark_application(key, raw_data)
 
 
 def create_spark_application(*, path, thresholds=None) -> SparkApplication:

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -301,7 +301,7 @@ class UnparsedLogSparkApplicationLoader(AbstractSparkApplicationDataLoader[Appli
     """
     From a raw set of Spark log lines, constructs a SparkApplication
     """
-    _json_lines_loader: JSONLinesDataLoader = None
+    _json_lines_loader: JSONLinesDataLoader
 
     def __init__(
         self,
@@ -981,27 +981,35 @@ class AmbiguousLogFormatSparkApplicationLoader(AbstractSparkApplicationDataLoade
     #  un/parsed SparkApplication loader based on the underlying data, and those loaders have these methods
     #  implemented already
     def compute_sql_info(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
         pass
 
     def compute_executor_info(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
         pass
 
     def compute_all_job_data(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
         pass
 
     def compute_all_task_data(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
         pass
 
     def compute_all_stage_data(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
         pass
 
     def compute_all_driver_accum_data(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
         pass
 
     def compute_all_metadata(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
         pass
 
     def compute_recent_events(self, raw_data: DataType, spark_app: SparkApplication) -> SparkApplication:
+        """See comment above for why this is left un-implemented"""
         pass
 
 

--- a/tests/loaders/test_archive_size_assertions.py
+++ b/tests/loaders/test_archive_size_assertions.py
@@ -35,7 +35,6 @@ async def test_loading_succeeds_as_expected(archive_paths):
         for _, data in file_iter:
             for _ in data:
                 continue
-            continue
 
 
 @pytest.mark.asyncio
@@ -47,7 +46,6 @@ async def test_archive_size_limit_error(archive_paths):
             for _, data in await file_loader.load(str(path)):
                 for _ in data:
                     continue
-                continue
             assert False, f"Expected an ArchiveTooLargeError error to be raised while loading filepath: {path}"
         except ArchiveTooLargeError as e:
             assert e

--- a/tests/loaders/test_archive_size_assertions.py
+++ b/tests/loaders/test_archive_size_assertions.py
@@ -32,7 +32,9 @@ async def test_loading_succeeds_as_expected(archive_paths):
 
         # Need to actually consume the iterator in order to test this behaviour; otherwise, the file is not
         #  actually ever read in from disk
-        for _ in file_iter:
+        for _, data in file_iter:
+            for _ in data:
+                continue
             continue
 
 
@@ -42,7 +44,9 @@ async def test_archive_size_limit_error(archive_paths):
     file_loader = LocalFileBlobDataLoader(extraction_thresholds=archive_thresholds)
     for path in archive_paths:
         try:
-            for _ in await file_loader.load(str(path)):
+            for _, data in await file_loader.load(str(path)):
+                for _ in data:
+                    continue
                 continue
             assert False, f"Expected an ArchiveTooLargeError error to be raised while loading filepath: {path}"
         except ArchiveTooLargeError as e:

--- a/tests/test_parse_local.py
+++ b/tests/test_parse_local.py
@@ -8,7 +8,7 @@ from tests import assert_all_files_equivalent, PARSED_KEYS, APP_NAME_INCORRECT_M
 
 
 def get_spark_app_from_raw_log(event_log_path):
-    return create_spark_application(spark_eventlog_path=str(event_log_path))
+    return create_spark_application(path=str(event_log_path))
 
 
 def get_parsed_log(event_log_path):
@@ -76,5 +76,5 @@ def test_parsed_log():
     Test that re-hydrating a parsed spark application contains all the keys we would expect it to
     """
     event_log_path = Path(ROOT_DIR, "logs", "similarity_parsed.json.gz").resolve()
-    rehydrated = create_spark_application(spark_eventlog_parsed_path=str(event_log_path)).to_dict()
+    rehydrated = create_spark_application(path=str(event_log_path)).to_dict()
     assert all(key in rehydrated for key in PARSED_KEYS), "Not all keys are present in re-hydrated Spark application"

--- a/tests/test_parse_s3.py
+++ b/tests/test_parse_s3.py
@@ -58,7 +58,6 @@ def assert_file_parsed_properly(eventlog_url, eventlog_file, eventlog_s3_dir, cr
     assert metadata['application_info']['spark_version'] is not None
 
 
-
 @pytest.mark.parametrize(
     "event_log_url",
     [
@@ -71,7 +70,9 @@ def assert_file_parsed_properly(eventlog_url, eventlog_file, eventlog_s3_dir, cr
     [(Path(ROOT_DIR, "logs", "emr.zip"), "airlinedelay/jb-42K1E16/")],
 )
 def test_emr_log_from_s3(event_log_url, event_log_file_archive, event_log_s3_dir, mocker):
-    create_app = lambda: create_spark_application(spark_eventlog_path=str(event_log_url))
+    def create_app():
+        return create_spark_application(path=str(event_log_url))
+
     assert_file_parsed_properly(event_log_url, event_log_file_archive, event_log_s3_dir, create_app, mocker)
 
 
@@ -87,7 +88,9 @@ def test_emr_log_from_s3(event_log_url, event_log_file_archive, event_log_s3_dir
     [(Path(ROOT_DIR, "logs", "similarity_parsed.json.gz"), "/foo/bar-baz/")],
 )
 def test_parsed_log_from_s3(event_log_url, event_log_file_archive, event_log_s3_dir, mocker):
-    create_app = lambda: create_spark_application(spark_eventlog_parsed_path=str(event_log_url))
+    def create_app():
+        return create_spark_application(path=str(event_log_url))
+
     assert_file_parsed_properly(event_log_url, event_log_file_archive, event_log_s3_dir, create_app, mocker)
 
 
@@ -103,7 +106,9 @@ def test_parsed_log_from_s3(event_log_url, event_log_file_archive, event_log_s3_
     [(Path(ROOT_DIR, "logs", "databricks.json"), "/foo/bar-baz/")],
 )
 def test_raw_log_from_s3(event_log_url, event_log_file_archive, event_log_s3_dir, mocker):
-    create_app = lambda: create_spark_application(spark_eventlog_path=str(event_log_url))
+    def create_app():
+        return create_spark_application(path=str(event_log_url))
+
     assert_file_parsed_properly(event_log_url, event_log_file_archive, event_log_s3_dir, create_app, mocker)
 
 
@@ -155,7 +160,7 @@ def test_databricks_log_from_s3_dir(event_log_url, event_log_file_archive, event
 
     with stubber:
         mocker.patch(BOTO_CLIENT_STUB_TARGET, new=lambda _: s3)
-        spark_app = create_spark_application(spark_eventlog_path=str(event_log_url))
+        spark_app = create_spark_application(path=str(event_log_url))
 
     stubber.assert_no_pending_responses()
 


### PR DESCRIPTION
[PROD-611 Disambiguate parsed vs. unparsed logs without parsing the file multiple times](https://synccomputing.atlassian.net/browse/PROD-611?atlOrigin=eyJpIjoiOGY4NTg2ZmUwODQxNGM1Y2FiYTM4YzFiNjFjYTVmMzYiLCJwIjoiaiJ9)

- Adds the ability for the JSON Lines loader to handle regular JSON files. This is done by attempting to read in all of the lines for a given file if the first line is not a well-formed JSON object. Alternatively, we can allow the JSON Lines loader to just skip all of the lines in these files. We are able to do this because now our File Loaders yield tuples of `Path, Iterator[bytes]` which allows callers to know when we have consumed all of the data for a given file (and thus are moving on to the next one). Previously, there was no delineation between multiple files, and the whole thing was just one long stream of bytes.
- Addresses some leftover feedback from #31 

[PROD-611]: https://synccomputing.atlassian.net/browse/PROD-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROD-611]: https://synccomputing.atlassian.net/browse/PROD-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ