### PR TITLE
Use orjson for saving as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "numpy==1.21.4",
     "pandas==1.5.2",
     "orjson==3.8.3",
+    "ujson==5.7.0",
     "stream-unzip==0.0.70",
     "pydantic==1.9.0",
     "requests==2.26.0",

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -1,7 +1,7 @@
 import abc
 import asyncio
 import gzip
-import json
+import orjson
 import logging
 import os
 import time
@@ -40,7 +40,7 @@ class SparkApplication:
 
         # TODO - these DataFrames should be better documented
         self.jobData: pd.DataFrame = None
-        self.stageDate: pd.DataFrame = None
+        self.stageData: pd.DataFrame = None
         self.taskData: pd.DataFrame = None
         self.accumData: pd.DataFrame = None
 
@@ -90,11 +90,11 @@ class SparkApplication:
             filepath = inputFile + "-sync"
 
         if compress is False:
-            with open(filepath + ".json", "w") as fout:
-                fout.write(json.dumps(saveDat))
+            with open(filepath + ".json", "wb") as fout:
+                fout.write(orjson.dumps(saveDat))
         elif compress is True:
-            with gzip.open(filepath + ".json.gz", "w") as fout:
-                fout.write(json.dumps(saveDat).encode("ascii"))
+            with gzip.open(filepath + ".json.gz", "wb") as fout:
+                fout.write(orjson.dumps(saveDat))
         logger.info("Saved object locally to: %s" % (filepath))
 
     def save_to_s3(self, saveDat, filepath, compress):
@@ -106,15 +106,15 @@ class SparkApplication:
         key = ("/".join(path[1:])).lstrip("/") + ".json"
 
         if compress is False:
-            s3.put_object(Bucket=bucket, Body=json.dumps(saveDat).encode("utf-8"), Key=key)
+            s3.put_object(Bucket=bucket, Body=orjson.dumps(saveDat), Key=key)
         else:
-            dat = gzip.compress(json.dumps(saveDat).encode("utf-8"))
+            dat = gzip.compress(orjson.dumps(saveDat))
             s3.put_object(Bucket=bucket, Body=dat, Key=key + ".gz")
 
         logger.info("Saved object to cloud: %s" % (key))
 
 
-SparkApplicationRawDataType = TypeVar("DataType")
+SparkApplicationRawDataType = TypeVar("SparkApplicationRawDataType")
 SparkApplicationLoaderKey = TypeVar("SparkApplicationLoaderKey")
 
 


### PR DESCRIPTION
Fixes an issue where `Nan`s may show up in the JSON serialized output in some of our columns that are `float`s. This may happen if we write `None` into a column that already contains some float values (or if we write a float after already writing a None) -

![Screenshot 2023-01-18 at 3 17 13 PM](https://user-images.githubusercontent.com/117235708/213316272-9202b7d5-dfaa-4b7d-87cc-85b1aedff742.png)

Switching from `json` --> `orjson` means that `NaN`s will show up in the JSON output as `null`s -

![Screenshot 2023-01-18 at 3 16 56 PM](https://user-images.githubusercontent.com/117235708/213316332-4dc9ae00-e623-4be6-83d2-8d4179f9cee3.png)

This is because `orjson` will convert any encountered `NaN`s to `null`, since `NaN` is not valid JSON - https://github.com/ijl/orjson#float