### PR TITLE
Make FileChunkStreamWrapper significantly faster for large files, modify some chunk sizes

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,2 +1,2 @@
 """Tools for providing Spark event log"""
-__version__ = "0.4.3"
+__version__ = "0.4.4"


### PR DESCRIPTION
When testing this read code against large eventlogs (both parsed and un-parsed), the previous naive implementations made it obvious how slow they were, largely due to copying data around way more than is necessary. This PR removes a lot of those copies and moves towards a more manual method of chunk/buffer management in `FileChunkStreamWrapper`'s `read` and `iter_lines` methods. This logic is certainly a bit more complicated than what we had before, but I think the performance gains pretty much speak for themselves -

- With the old implementation, we could not process more than 1/4 of the Thermofischer eventlog (1.6GB all compressed, 22GB uncompressed) in over an hour. With these changes, I can now process that file locally in ~12 minutes
- Relatively large, parsed eventlogs (coming from Insider, for example this one - https://synccomputing-webapp-production.s3.us-west-2.amazonaws.com/predictions/8fe3bcc9-1b7b-4f0b-8c6d-a2347196c393/b7bb7cc3-b212-47d6-a985-faffae77efcc/2023-01-19T05%3A54%3A02Z/parsed-j-1I772OJXCARCY_s-CHALYX2K71IH.json) were taking hours to process on Heroku. I can now get through that same file in 2 - 3 minutes, including downloading the whole file from S3

I have also run this through our integration tests in `sync_backend`, which are all passing -

<img width="942" alt="Screenshot 2023-01-24 at 2 18 28 PM" src="https://user-images.githubusercontent.com/117235708/214433828-bb105942-3c10-4b25-b583-525336ff3760.png">


Comments inline...