### PR TITLE
Re-enable Databricks autoscaling jobs

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,2 +1,2 @@
 """Tools for providing Spark event log"""
-__version__ = "0.4.7"
+__version__ = "0.5.0"


### PR DESCRIPTION
In pursuit of re-enabling DBX, this removes the autoscaling restriction for Databricks event log submissions