### PR TITLE
Add handling for executor.start_time being None

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,2 +1,2 @@
 """Tools for providing Spark event log"""
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
Currently some Databricks event log submissions fail with an error caused by some `executor.start_time` being `None` -


![Screenshot 2023-04-19 at 6 59 57 PM](https://user-images.githubusercontent.com/117235708/233239473-009665e2-f292-4ca4-bb7e-f54734bf8a84.png)
