### PR TITLE
Define SparkApplication better, allow better configuration of concrete SparkApplication type

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,2 +1,2 @@
 """Tools for providing Spark event log"""
-__version__ = "0.5.1"
+__version__ = "0.6.0"


### PR DESCRIPTION
This PR basically allows us to get better type alignment when subclassing `SparkApplication` in projects that import this library. Additionally, it better-defines the `metadata` field of `SparkApplication`