### PR TITLE
Update some AbstractSparkApplicationDataLoader methods to be async

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,2 +1,2 @@
 """Tools for providing Spark event log"""
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
Related to some work in `sync_backend`, there is increasing usage of `async` when loading various parts of data to construct a Spark Application object. This PR converts a few methods to be `async` in order to support that.