### PR TITLE
CUS-37-Support-for-non-data-jobs

### DIFF
--- a/spark_log_parser/__init__.py
+++ b/spark_log_parser/__init__.py
@@ -1,2 +1,2 @@
 """Tools for providing Spark event log"""
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/spark_log_parser/parsing_models/application_model.py
+++ b/spark_log_parser/parsing_models/application_model.py
@@ -4,7 +4,11 @@ from typing import Iterator
 import numpy
 
 from .dag_model import DagModel
-from .exceptions import UrgentEventValidationException, LogSubmissionException, LazyEventValidationException
+from .exceptions import (
+    LazyEventValidationException,
+    LogSubmissionException,
+    UrgentEventValidationException,
+)
 from .executor_model import ExecutorModel
 from .job_model import JobModel
 from .stage_model import StageModel
@@ -241,9 +245,11 @@ class ApplicationModel:
             expected_rollover_log_numbers_seen = set(range(max_rollover + 1))
             if expected_rollover_log_numbers_seen.difference(rollover_log_numbers_seen):
                 raise LogSubmissionException(
-                    error_message=("Rollover logs were detected, but there were fewer than expected.\n"
-                                   + f"Expected to receive rollover numbers: {', '.join((str(n) for n in expected_rollover_log_numbers_seen))}, "
-                                   + f"but instead received: {', '.join((str(n) for n in sorted(rollover_log_numbers_seen)))} ")
+                    error_message=(
+                        "Rollover logs were detected, but there were fewer than expected.\n"
+                        + f"Expected to receive rollover numbers: {', '.join((str(n) for n in expected_rollover_log_numbers_seen))}, "
+                        + f"but instead received: {', '.join((str(n) for n in sorted(rollover_log_numbers_seen)))} "
+                    )
                 )
 
         for task in self.tasks:

--- a/spark_log_parser/parsing_models/application_model.py
+++ b/spark_log_parser/parsing_models/application_model.py
@@ -5,7 +5,6 @@ import numpy
 
 from .dag_model import DagModel
 from .exceptions import (
-    LazyEventValidationException,
     LogSubmissionException,
     UrgentEventValidationException,
 )

--- a/spark_log_parser/parsing_models/application_model.py
+++ b/spark_log_parser/parsing_models/application_model.py
@@ -251,9 +251,6 @@ class ApplicationModel:
             stage = self.stages[stage_id]
             stage.add_task(task)
 
-        if len(self.stages) == 0:
-            raise LazyEventValidationException("No stages detected in Spark Eventlog")
-
         for stage_id, stage in self.stages.items():
             if stage.submission_time is None:
                 raise UrgentEventValidationException(missing_event=f"Stage {stage_id} Submit")

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -577,7 +577,7 @@ class UnparsedLogSparkApplicationLoader(
     ) -> SparkApplication:
         app_model = raw_data
         t1 = time.time()
-        dfs: list[pd.DataFrame] = [pd.DataFrame()]
+        dfs: list[pd.DataFrame] = []
         ref_time = app_model.start_time
         for jid, job in app_model.jobs.items():
 
@@ -599,8 +599,10 @@ class UnparsedLogSparkApplicationLoader(
                     }
                 )
             )
-
-        df = pd.concat(dfs)
+        if dfs:
+            df = pd.concat(dfs)
+        else:
+            df = pd.DataFrame()
         if len(df) > 0:
             df = df.sort_values(by="job_id")
             df = df.set_index("job_id")

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -149,7 +149,9 @@ class AbstractSparkApplicationDataLoader(
     """
 
     def __init__(
-        self, spark_application_constructor: Callable[[], SparkApplicationClass] | None = None, **kwargs
+        self,
+        spark_application_constructor: Callable[[], SparkApplicationClass] | None = None,
+        **kwargs,
     ):
         super().__init__(**kwargs)
 
@@ -289,7 +291,9 @@ class AbstractSparkApplicationDataLoader(
         raw_datas = await self.load_raw_datas(keys)
         # Make sure we bubble up any Exceptions from load_raw_datas appropriately
         return [
-            await self.construct_spark_application(key, data) if not isinstance(data, Exception) else data
+            await self.construct_spark_application(key, data)
+            if not isinstance(data, Exception)
+            else data
             for (key, data) in zip(keys, raw_datas)
         ]
 
@@ -1060,9 +1064,7 @@ class BaseAmbiguousLogFormatSparkApplicationLoader(
     async def _construct_from_parsed_representation(self, key: str, data: dict):
         return await self._parsed_app_loader.construct_spark_application(key, data)
 
-    async def _construct_from_unparsed_representation(
-        self, key: str, data: ApplicationModel
-    ):
+    async def _construct_from_unparsed_representation(self, key: str, data: ApplicationModel):
         return await self._unparsed_app_loader.construct_spark_application(key, data)
 
     async def _load_raw_datas(

--- a/spark_log_parser/parsing_models/application_model_v2.py
+++ b/spark_log_parser/parsing_models/application_model_v2.py
@@ -573,7 +573,7 @@ class UnparsedLogSparkApplicationLoader(
     ) -> SparkApplication:
         app_model = raw_data
         t1 = time.time()
-        dfs: list[pd.DataFrame] = []
+        dfs: list[pd.DataFrame] = [pd.DataFrame()]
         ref_time = app_model.start_time
         for jid, job in app_model.jobs.items():
 


### PR DESCRIPTION
See https://synccomputing.atlassian.net/jira/servicedesk/projects/CUS/queues/custom/1/CUS-37. These changes remove restrictions requiring jobs/stages/tasks to be present in the eventlog when parsed by spark_log_parser. This is coupled with changes in the backend: https://github.com/synccomputingcode/sync_backend/pull/442. I've tested this on the job listed in the jira ticket and can successfully create submissions/recommendations. Alot of these changes are just formatting from "make format", didn't realize that the checks are less strict here than in backend.